### PR TITLE
Rename GTK+ to GTK

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@
 
 ## GUI Programming
 
-- [GTK+](https://www.gtk.org/) - The de facto library for GUI development in Vala. Bindings are included with the vala compiler.
+- [GTK](https://www.gtk.org/) - The de facto library for GUI development in Vala. Bindings are included with the vala compiler.
 
 ## Multimedia Processing
 


### PR DESCRIPTION
They have officially dropped the plus sign. See https://www.gtk.org.